### PR TITLE
refactor interface between scorch and segment impls

### DIFF
--- a/index/scorch/introducer.go
+++ b/index/scorch/introducer.go
@@ -21,7 +21,6 @@ import (
 	"github.com/RoaringBitmap/roaring"
 	"github.com/blugelabs/bleve/index"
 	"github.com/blugelabs/bleve/index/scorch/segment"
-	"github.com/blugelabs/bleve/index/scorch/segment/zap"
 )
 
 type segmentIntroduction struct {
@@ -409,11 +408,11 @@ func (s *Scorch) introduceMerge(nextMerge *segmentMerge) {
 		atomic.AddUint64(&s.stats.TotIntroducedSegmentsMerge, 1)
 
 		switch nextMerge.new.(type) {
-		case *zap.SegmentBase:
+		case segment.PersistedSegment:
+			fileSegments++
+		default:
 			docsToPersistCount += nextMerge.new.Count() - newSegmentDeleted.GetCardinality()
 			memSegments++
-		case *zap.Segment:
-			fileSegments++
 		}
 	}
 
@@ -520,9 +519,9 @@ func (s *Scorch) revertToSnapshot(revertTo *snapshotReversion) error {
 
 func isMemorySegment(s *SegmentSnapshot) bool {
 	switch s.segment.(type) {
-	case *zap.SegmentBase:
-		return true
-	default:
+	case segment.PersistedSegment:
 		return false
+	default:
+		return true
 	}
 }

--- a/index/scorch/merge.go
+++ b/index/scorch/merge.go
@@ -25,7 +25,6 @@ import (
 	"github.com/RoaringBitmap/roaring"
 	"github.com/blugelabs/bleve/index/scorch/mergeplan"
 	"github.com/blugelabs/bleve/index/scorch/segment"
-	"github.com/blugelabs/bleve/index/scorch/segment/zap"
 )
 
 func (s *Scorch) mergerLoop() {
@@ -131,18 +130,18 @@ func (s *Scorch) parseMergePlannerOptions() (*mergeplan.MergePlanOptions,
 
 func (s *Scorch) planMergeAtSnapshot(ourSnapshot *IndexSnapshot,
 	options *mergeplan.MergePlanOptions) error {
-	// build list of zap segments in this snapshot
-	var onlyZapSnapshots []mergeplan.Segment
+	// build list of persisted segments in this snapshot
+	var onlyPersistedSnapshots []mergeplan.Segment
 	for _, segmentSnapshot := range ourSnapshot.segment {
-		if _, ok := segmentSnapshot.segment.(*zap.Segment); ok {
-			onlyZapSnapshots = append(onlyZapSnapshots, segmentSnapshot)
+		if _, ok := segmentSnapshot.segment.(segment.PersistedSegment); ok {
+			onlyPersistedSnapshots = append(onlyPersistedSnapshots, segmentSnapshot)
 		}
 	}
 
 	atomic.AddUint64(&s.stats.TotFileMergePlan, 1)
 
 	// give this list to the planner
-	resultMergePlan, err := mergeplan.Plan(onlyZapSnapshots, options)
+	resultMergePlan, err := mergeplan.Plan(onlyPersistedSnapshots, options)
 	if err != nil {
 		atomic.AddUint64(&s.stats.TotFileMergePlanErr, 1)
 		return fmt.Errorf("merge planning err: %v", err)
@@ -169,24 +168,24 @@ func (s *Scorch) planMergeAtSnapshot(ourSnapshot *IndexSnapshot,
 
 		oldMap := make(map[uint64]*SegmentSnapshot)
 		newSegmentID := atomic.AddUint64(&s.nextSegmentID, 1)
-		segmentsToMerge := make([]*zap.Segment, 0, len(task.Segments))
+		segmentsToMerge := make([]segment.Segment, 0, len(task.Segments))
 		docsToDrop := make([]*roaring.Bitmap, 0, len(task.Segments))
 
 		for _, planSegment := range task.Segments {
 			if segSnapshot, ok := planSegment.(*SegmentSnapshot); ok {
 				oldMap[segSnapshot.id] = segSnapshot
-				if zapSeg, ok := segSnapshot.segment.(*zap.Segment); ok {
+				if persistedSeg, ok := segSnapshot.segment.(segment.PersistedSegment); ok {
 					if segSnapshot.LiveSize() == 0 {
 						atomic.AddUint64(&s.stats.TotFileMergeSegmentsEmpty, 1)
 						oldMap[segSnapshot.id] = nil
 					} else {
-						segmentsToMerge = append(segmentsToMerge, zapSeg)
+						segmentsToMerge = append(segmentsToMerge, segSnapshot.segment)
 						docsToDrop = append(docsToDrop, segSnapshot.deleted)
 					}
 					// track the files getting merged for unsetting the
 					// removal ineligibility. This helps to unflip files
 					// even with fast merger, slow persister work flows.
-					path := zapSeg.Path()
+					path := persistedSeg.Path()
 					filenames = append(filenames,
 						strings.TrimPrefix(path, s.path+string(os.PathSeparator)))
 				}
@@ -203,7 +202,7 @@ func (s *Scorch) planMergeAtSnapshot(ourSnapshot *IndexSnapshot,
 			fileMergeZapStartTime := time.Now()
 
 			atomic.AddUint64(&s.stats.TotFileMergeZapBeg, 1)
-			newDocNums, _, err := zap.Merge(segmentsToMerge, docsToDrop, path,
+			newDocNums, _, err := s.segWrapper.Merge(segmentsToMerge, docsToDrop, path,
 				DefaultChunkFactor, s.closeCh, s)
 			atomic.AddUint64(&s.stats.TotFileMergeZapEnd, 1)
 
@@ -222,13 +221,13 @@ func (s *Scorch) planMergeAtSnapshot(ourSnapshot *IndexSnapshot,
 				return fmt.Errorf("merging failed: %v", err)
 			}
 
-			seg, err = zap.Open(path)
+			seg, err = s.segWrapper.Open(path)
 			if err != nil {
 				s.unmarkIneligibleForRemoval(filename)
 				atomic.AddUint64(&s.stats.TotFileMergePlanTasksErr, 1)
 				return err
 			}
-			err = zap.ValidateMerge(segmentsToMerge, nil, docsToDrop, seg.(*zap.Segment))
+			err = s.segWrapper.ValidateMerge(segmentsToMerge, docsToDrop, seg)
 			if err != nil {
 				s.unmarkIneligibleForRemoval(filename)
 				return fmt.Errorf("merge validation failed: %v", err)
@@ -297,7 +296,7 @@ type segmentMerge struct {
 // persisted segment, and synchronously introduce that new segment
 // into the root
 func (s *Scorch) mergeSegmentBases(snapshot *IndexSnapshot,
-	sbs []*zap.SegmentBase, sbsDrops []*roaring.Bitmap, sbsIndexes []int,
+	sbs []segment.Segment, sbsDrops []*roaring.Bitmap, sbsIndexes []int,
 	chunkFactor uint32) (*IndexSnapshot, uint64, error) {
 	atomic.AddUint64(&s.stats.TotMemMergeBeg, 1)
 
@@ -310,7 +309,7 @@ func (s *Scorch) mergeSegmentBases(snapshot *IndexSnapshot,
 	path := s.path + string(os.PathSeparator) + filename
 
 	newDocNums, _, err :=
-		zap.MergeSegmentBases(sbs, sbsDrops, path, chunkFactor, s.closeCh, s)
+		s.segWrapper.Merge(sbs, sbsDrops, path, chunkFactor, s.closeCh, s)
 
 	atomic.AddUint64(&s.stats.TotMemMergeZapEnd, 1)
 
@@ -325,12 +324,12 @@ func (s *Scorch) mergeSegmentBases(snapshot *IndexSnapshot,
 		return nil, 0, err
 	}
 
-	seg, err := zap.Open(path)
+	seg, err := s.segWrapper.Open(path)
 	if err != nil {
 		atomic.AddUint64(&s.stats.TotMemMergeErr, 1)
 		return nil, 0, err
 	}
-	err = zap.ValidateMerge(nil, sbs, sbsDrops, seg.(*zap.Segment))
+	err = s.segWrapper.ValidateMerge(sbs, sbsDrops, seg)
 	if err != nil {
 		return nil, 0, fmt.Errorf("in-memory merge validation failed: %v", err)
 	}

--- a/index/scorch/optimize.go
+++ b/index/scorch/optimize.go
@@ -18,10 +18,8 @@ import (
 	"fmt"
 
 	"github.com/RoaringBitmap/roaring"
-
 	"github.com/blugelabs/bleve/index"
 	"github.com/blugelabs/bleve/index/scorch/segment"
-	"github.com/blugelabs/bleve/index/scorch/segment/zap"
 )
 
 var OptimizeConjunction = true
@@ -81,25 +79,25 @@ func (o *OptimizeTFRConjunction) Finish() (index.Optimized, error) {
 	}
 
 	for i := range o.snapshot.segment {
-		itr0, ok := o.tfrs[0].iterators[i].(*zap.PostingsIterator)
-		if !ok || itr0.ActualBM == nil {
+		itr0, ok := o.tfrs[0].iterators[i].(segment.OptimizablePostingsIterator)
+		if !ok || itr0.ActualBitmap() == nil {
 			continue
 		}
 
-		itr1, ok := o.tfrs[1].iterators[i].(*zap.PostingsIterator)
-		if !ok || itr1.ActualBM == nil {
+		itr1, ok := o.tfrs[1].iterators[i].(segment.OptimizablePostingsIterator)
+		if !ok || itr1.ActualBitmap() == nil {
 			continue
 		}
 
-		bm := roaring.And(itr0.ActualBM, itr1.ActualBM)
+		bm := roaring.And(itr0.ActualBitmap(), itr1.ActualBitmap())
 
 		for _, tfr := range o.tfrs[2:] {
-			itr, ok := tfr.iterators[i].(*zap.PostingsIterator)
-			if !ok || itr.ActualBM == nil {
+			itr, ok := tfr.iterators[i].(segment.OptimizablePostingsIterator)
+			if !ok || itr.ActualBitmap() == nil {
 				continue
 			}
 
-			bm.And(itr.ActualBM)
+			bm.And(itr.ActualBitmap())
 		}
 
 		// in this conjunction optimization, the postings iterators
@@ -107,10 +105,9 @@ func (o *OptimizeTFRConjunction) Finish() (index.Optimized, error) {
 		// regular conjunction searcher machinery will still be used,
 		// but the underlying bitmap will be smaller.
 		for _, tfr := range o.tfrs {
-			itr, ok := tfr.iterators[i].(*zap.PostingsIterator)
-			if ok && itr.ActualBM != nil {
-				itr.ActualBM = bm
-				itr.Actual = bm.Iterator()
+			itr, ok := tfr.iterators[i].(segment.OptimizablePostingsIterator)
+			if ok && itr.ActualBitmap() != nil {
+				itr.ReplaceActual(bm)
 			}
 		}
 	}
@@ -191,9 +188,9 @@ OUTER:
 				continue OUTER
 			}
 
-			itr, ok := tfr.iterators[i].(*zap.PostingsIterator)
+			itr, ok := tfr.iterators[i].(segment.OptimizablePostingsIterator)
 			if !ok {
-				// We optimize zap postings iterators only.
+				// We only optimize postings iterators that support this operation.
 				return nil, nil
 			}
 
@@ -201,7 +198,7 @@ OUTER:
 			// can perform several optimizations up-front here.
 			docNum1Hit, ok := itr.DocNum1Hit()
 			if ok {
-				if docNum1Hit == zap.DocNum1HitFinished {
+				if o.snapshot.parent.segWrapper.IsDocNum1HitFinished(docNum1Hit) {
 					// An empty docNum here means the entire AND is empty.
 					oTFR.iterators[i] = segment.AnEmptyPostingsIterator
 					continue OUTER
@@ -220,14 +217,14 @@ OUTER:
 				continue
 			}
 
-			if itr.ActualBM == nil {
+			if itr.ActualBitmap() == nil {
 				// An empty actual bitmap means the entire AND is empty.
 				oTFR.iterators[i] = segment.AnEmptyPostingsIterator
 				continue OUTER
 			}
 
 			// Collect the actual bitmap for more processing later.
-			actualBMs = append(actualBMs, itr.ActualBM)
+			actualBMs = append(actualBMs, itr.ActualBitmap())
 		}
 
 		if docNum1HitLastOk {
@@ -245,8 +242,8 @@ OUTER:
 
 			// The actual bitmaps and docNum1Hits all contain or have
 			// the same 1-hit docNum, so that's our AND'ed result.
-			oTFR.iterators[i], err = zap.PostingsIteratorFrom1Hit(
-				docNum1HitLast, zap.NormBits1Hit, false, false)
+			oTFR.iterators[i], err = o.snapshot.parent.segWrapper.PostingsIteratorFrom1Hit(
+				docNum1HitLast, false, false)
 			if err != nil {
 				return nil, nil
 			}
@@ -263,7 +260,7 @@ OUTER:
 
 		if len(actualBMs) == 1 {
 			// If we've only 1 actual bitmap, then that's our result.
-			oTFR.iterators[i], err = zap.PostingsIteratorFromBitmap(
+			oTFR.iterators[i], err = o.snapshot.parent.segWrapper.PostingsIteratorFromBitmap(
 				actualBMs[0], false, false)
 			if err != nil {
 				return nil, nil
@@ -279,7 +276,7 @@ OUTER:
 			bm.And(actualBM)
 		}
 
-		oTFR.iterators[i], err = zap.PostingsIteratorFromBitmap(
+		oTFR.iterators[i], err = o.snapshot.parent.segWrapper.PostingsIteratorFromBitmap(
 			bm, false, false)
 		if err != nil {
 			return nil, nil
@@ -337,13 +334,13 @@ func (o *OptimizeTFRDisjunctionUnadorned) Finish() (rv index.Optimized, err erro
 		var cMax uint64
 
 		for _, tfr := range o.tfrs {
-			itr, ok := tfr.iterators[i].(*zap.PostingsIterator)
+			itr, ok := tfr.iterators[i].(segment.OptimizablePostingsIterator)
 			if !ok {
 				return nil, nil
 			}
 
-			if itr.ActualBM != nil {
-				c := itr.ActualBM.GetCardinality()
+			if itr.ActualBitmap() != nil {
+				c := itr.ActualBitmap().GetCardinality()
 				if cMax < c {
 					cMax = c
 				}
@@ -379,7 +376,7 @@ func (o *OptimizeTFRDisjunctionUnadorned) Finish() (rv index.Optimized, err erro
 		actualBMs = actualBMs[:0]
 
 		for _, tfr := range o.tfrs {
-			itr, ok := tfr.iterators[i].(*zap.PostingsIterator)
+			itr, ok := tfr.iterators[i].(segment.OptimizablePostingsIterator)
 			if !ok {
 				return nil, nil
 			}
@@ -390,8 +387,8 @@ func (o *OptimizeTFRDisjunctionUnadorned) Finish() (rv index.Optimized, err erro
 				continue
 			}
 
-			if itr.ActualBM != nil {
-				actualBMs = append(actualBMs, itr.ActualBM)
+			if itr.ActualBitmap() != nil {
+				actualBMs = append(actualBMs, itr.ActualBitmap())
 			}
 		}
 
@@ -410,7 +407,7 @@ func (o *OptimizeTFRDisjunctionUnadorned) Finish() (rv index.Optimized, err erro
 
 		bm.AddMany(docNums)
 
-		oTFR.iterators[i], err = zap.PostingsIteratorFromBitmap(bm, false, false)
+		oTFR.iterators[i], err = o.snapshot.parent.segWrapper.PostingsIteratorFromBitmap(bm, false, false)
 		if err != nil {
 			return nil, nil
 		}

--- a/index/scorch/persister.go
+++ b/index/scorch/persister.go
@@ -32,7 +32,6 @@ import (
 	"github.com/RoaringBitmap/roaring"
 	"github.com/blugelabs/bleve/index"
 	"github.com/blugelabs/bleve/index/scorch/segment"
-	"github.com/blugelabs/bleve/index/scorch/segment/zap"
 	bolt "github.com/etcd-io/bbolt"
 )
 
@@ -360,13 +359,13 @@ var DefaultMinSegmentsForInMemoryMerge = 2
 func (s *Scorch) persistSnapshotMaybeMerge(snapshot *IndexSnapshot) (
 	bool, error) {
 	// collect the in-memory zap segments (SegmentBase instances)
-	var sbs []*zap.SegmentBase
+	var sbs []segment.Segment
 	var sbsDrops []*roaring.Bitmap
 	var sbsIndexes []int
 
 	for i, segmentSnapshot := range snapshot.segment {
-		if sb, ok := segmentSnapshot.segment.(*zap.SegmentBase); ok {
-			sbs = append(sbs, sb)
+		if _, ok := segmentSnapshot.segment.(segment.PersistedSegment); !ok {
+			sbs = append(sbs, segmentSnapshot.segment)
 			sbsDrops = append(sbsDrops, segmentSnapshot.deleted)
 			sbsIndexes = append(sbsIndexes, i)
 		}
@@ -459,13 +458,13 @@ func (s *Scorch) persistSnapshotDirect(snapshot *IndexSnapshot) (err error) {
 	if err != nil {
 		return err
 	}
-	err = metaBucket.Put([]byte("type"), []byte(zap.Type))
+	err = metaBucket.Put(boltMetaDataSegmentTypeKey, []byte(s.segWrapper.Type))
 	if err != nil {
 		return err
 	}
 	buf := make([]byte, binary.MaxVarintLen32)
-	binary.BigEndian.PutUint32(buf, zap.Version)
-	err = metaBucket.Put([]byte("version"), buf)
+	binary.BigEndian.PutUint32(buf, s.segWrapper.Version)
+	err = metaBucket.Put(boltMetaDataSegmentVersionKey, buf)
 	if err != nil {
 		return err
 	}
@@ -494,11 +493,19 @@ func (s *Scorch) persistSnapshotDirect(snapshot *IndexSnapshot) (err error) {
 			return err
 		}
 		switch seg := segmentSnapshot.segment.(type) {
-		case *zap.SegmentBase:
+		case segment.PersistedSegment:
+			path := seg.Path()
+			filename := strings.TrimPrefix(path, s.path+string(os.PathSeparator))
+			err = snapshotSegmentBucket.Put(boltPathKey, []byte(filename))
+			if err != nil {
+				return err
+			}
+			filenames = append(filenames, filename)
+		case segment.UnpersistedSegment:
 			// need to persist this to disk
 			filename := zapFileName(segmentSnapshot.id)
 			path := s.path + string(os.PathSeparator) + filename
-			err = zap.PersistSegmentBase(seg, path)
+			err = seg.Persist(path)
 			if err != nil {
 				return fmt.Errorf("error persisting segment: %v", err)
 			}
@@ -508,14 +515,7 @@ func (s *Scorch) persistSnapshotDirect(snapshot *IndexSnapshot) (err error) {
 				return err
 			}
 			filenames = append(filenames, filename)
-		case *zap.Segment:
-			path := seg.Path()
-			filename := strings.TrimPrefix(path, s.path+string(os.PathSeparator))
-			err = snapshotSegmentBucket.Put(boltPathKey, []byte(filename))
-			if err != nil {
-				return err
-			}
-			filenames = append(filenames, filename)
+
 		default:
 			return fmt.Errorf("unknown segment type: %T", seg)
 		}
@@ -553,7 +553,7 @@ func (s *Scorch) persistSnapshotDirect(snapshot *IndexSnapshot) (err error) {
 			}
 		}()
 		for segmentID, path := range newSegmentPaths {
-			newSegments[segmentID], err = zap.Open(path)
+			newSegments[segmentID], err = s.segWrapper.Open(path)
 			if err != nil {
 				return fmt.Errorf("error opening new segment at %s, %v", path, err)
 			}
@@ -609,6 +609,8 @@ var boltPathKey = []byte{'p'}
 var boltDeletedKey = []byte{'d'}
 var boltInternalKey = []byte{'i'}
 var boltMetaDataKey = []byte{'m'}
+var boltMetaDataSegmentTypeKey = []byte("type")
+var boltMetaDataSegmentVersionKey = []byte("version")
 
 func (s *Scorch) loadFromBolt() error {
 	return s.rootBolt.View(func(tx *bolt.Tx) error {
@@ -693,6 +695,21 @@ func (s *Scorch) loadSnapshot(snapshot *bolt.Bucket) (*IndexSnapshot, error) {
 		refs:     1,
 		creator:  "loadSnapshot",
 	}
+	// first we look for the meta-data bucket, this will tell us
+	// which segment type/version was used for this snapshot
+	// all operations for this scorch will use this type/version
+	metaBucket := snapshot.Bucket(boltMetaDataKey)
+	if metaBucket == nil {
+		_ = rv.DecRef()
+		return nil, fmt.Errorf("meta-data bucket missing")
+	}
+	segmentType := metaBucket.Get(boltMetaDataSegmentTypeKey)
+	segmentVersion := metaBucket.Get(boltMetaDataSegmentVersionKey)
+	err := s.loadSegmentWrapper(segmentType, segmentVersion)
+	if err != nil {
+		_ = rv.DecRef()
+		return nil, fmt.Errorf("unable to load correct segment wrapper: %v", err)
+	}
 	var running uint64
 	c := snapshot.Cursor()
 	for k, _ := c.First(); k != nil; k, _ = c.Next() {
@@ -737,7 +754,7 @@ func (s *Scorch) loadSegment(segmentBucket *bolt.Bucket) (*SegmentSnapshot, erro
 		return nil, fmt.Errorf("segment path missing")
 	}
 	segmentPath := s.path + string(os.PathSeparator) + string(pathBytes)
-	segment, err := zap.Open(segmentPath)
+	segment, err := s.segWrapper.Open(segmentPath)
 	if err != nil {
 		return nil, fmt.Errorf("error opening bolt segment: %v", err)
 	}

--- a/index/scorch/segment/segment.go
+++ b/index/scorch/segment/segment.go
@@ -50,6 +50,16 @@ type Segment interface {
 	DecRef() error
 }
 
+type UnpersistedSegment interface {
+	Segment
+	Persist(path string) error
+}
+
+type PersistedSegment interface {
+	Segment
+	Path() string
+}
+
 type TermDictionary interface {
 	PostingsList(term []byte, except *roaring.Bitmap, prealloc PostingsList) (PostingsList, error)
 
@@ -94,6 +104,12 @@ type PostingsIterator interface {
 	Advance(docNum uint64) (Posting, error)
 
 	Size() int
+}
+
+type OptimizablePostingsIterator interface {
+	ActualBitmap() *roaring.Bitmap
+	DocNum1Hit() (uint64, bool)
+	ReplaceActual(*roaring.Bitmap)
 }
 
 type Posting interface {

--- a/index/scorch/segment/zap/build.go
+++ b/index/scorch/segment/zap/build.go
@@ -16,9 +16,10 @@ package zap
 
 import (
 	"bufio"
-	"github.com/blugelabs/vellum"
 	"math"
 	"os"
+
+	"github.com/blugelabs/vellum"
 )
 
 const Version uint32 = 11
@@ -26,6 +27,10 @@ const Version uint32 = 11
 const Type string = "zap"
 
 const fieldNotUninverted = math.MaxUint64
+
+func (sb *SegmentBase) Persist(path string) error {
+	return PersistSegmentBase(sb, path)
+}
 
 // PersistSegmentBase persists SegmentBase in the zap file format.
 func PersistSegmentBase(sb *SegmentBase, path string) error {

--- a/index/scorch/segment/zap/build_test.go
+++ b/index/scorch/segment/zap/build_test.go
@@ -122,25 +122,29 @@ func buildTestSegment() (*SegmentBase, uint64, error) {
 		}
 	}
 
-	return AnalysisResultsToSegmentBase(results, 1024)
+	seg, size, err := AnalysisResultsToSegmentBase(results, 1024)
+	return seg.(*SegmentBase), size, err
 }
 
 func buildTestSegmentMulti() (*SegmentBase, uint64, error) {
 	results := buildTestAnalysisResultsMulti()
 
-	return AnalysisResultsToSegmentBase(results, 1024)
+	seg, size, err := AnalysisResultsToSegmentBase(results, 1024)
+	return seg.(*SegmentBase), size, err
 }
 
 func buildTestSegmentMultiWithChunkFactor(chunkFactor uint32) (*SegmentBase, uint64, error) {
 	results := buildTestAnalysisResultsMulti()
 
-	return AnalysisResultsToSegmentBase(results, chunkFactor)
+	seg, size, err := AnalysisResultsToSegmentBase(results, chunkFactor)
+	return seg.(*SegmentBase), size, err
 }
 
 func buildTestSegmentMultiWithDifferentFields(includeDocA, includeDocB bool) (*SegmentBase, uint64, error) {
 	results := buildTestAnalysisResultsMultiWithDifferentFields(includeDocA, includeDocB)
 
-	return AnalysisResultsToSegmentBase(results, 1024)
+	seg, size, err := AnalysisResultsToSegmentBase(results, 1024)
+	return seg.(*SegmentBase), size, err
 }
 
 func buildTestAnalysisResultsMulti() []*index.AnalysisResult {
@@ -552,5 +556,5 @@ func buildTestSegmentWithDefaultFieldMapping(chunkFactor uint32) (
 
 	sb, _, err := AnalysisResultsToSegmentBase(results, chunkFactor)
 
-	return sb, fields, err
+	return sb.(*SegmentBase), fields, err
 }

--- a/index/scorch/segment/zap/dict_test.go
+++ b/index/scorch/segment/zap/dict_test.go
@@ -99,7 +99,8 @@ func buildTestSegmentForDict() (*SegmentBase, uint64, error) {
 		},
 	}
 
-	return AnalysisResultsToSegmentBase(results, 1024)
+	seg, size, err := AnalysisResultsToSegmentBase(results, 1024)
+	return seg.(*SegmentBase), size, err
 }
 
 func TestDictionary(t *testing.T) {

--- a/index/scorch/segment/zap/merge.go
+++ b/index/scorch/segment/zap/merge.go
@@ -35,28 +35,35 @@ var DefaultFileMergerBufferSize = 1024 * 1024
 // on a new segment produced by a merge, by default this does nothing.
 // Caller should provide EITHER segments or memSegments, but not both.
 // This API is experimental and may be removed at any time.
-var ValidateMerge = func(segments []*Segment, memSegments []*SegmentBase, drops []*roaring.Bitmap, newSegment *Segment) error {
+var ValidateMerge = func(segments []seg.Segment, drops []*roaring.Bitmap, newSegment seg.Segment) error {
 	return nil
 }
 
 const docDropped = math.MaxUint64 // sentinel docNum to represent a deleted doc
 
-// Merge takes a slice of zap segments and bit masks describing which
+// Merge takes a slice of segments and bit masks describing which
 // documents may be dropped, and creates a new segment containing the
 // remaining data.  This new segment is built at the specified path,
 // with the provided chunkFactor.
-func Merge(segments []*Segment, drops []*roaring.Bitmap, path string,
+func Merge(segments []seg.Segment, drops []*roaring.Bitmap, path string,
 	chunkFactor uint32, closeCh chan struct{}, s seg.StatsReporter) (
 	[][]uint64, uint64, error) {
+
 	segmentBases := make([]*SegmentBase, len(segments))
 	for segmenti, segment := range segments {
-		segmentBases[segmenti] = &segment.SegmentBase
+		switch segmentx := segment.(type) {
+		case *Segment:
+			segmentBases[segmenti] = &segmentx.SegmentBase
+		case *SegmentBase:
+			segmentBases[segmenti] = segmentx
+		default:
+			panic(fmt.Sprintf("oops, unexpected segment type: %T", segment))
+		}
 	}
-
-	return MergeSegmentBases(segmentBases, drops, path, chunkFactor, closeCh, s)
+	return mergeSegmentBases(segmentBases, drops, path, chunkFactor, closeCh, s)
 }
 
-func MergeSegmentBases(segmentBases []*SegmentBase, drops []*roaring.Bitmap, path string,
+func mergeSegmentBases(segmentBases []*SegmentBase, drops []*roaring.Bitmap, path string,
 	chunkFactor uint32, closeCh chan struct{}, s seg.StatsReporter) (
 	[][]uint64, uint64, error) {
 	flag := os.O_RDWR | os.O_CREATE

--- a/index/scorch/segment/zap/new.go
+++ b/index/scorch/segment/zap/new.go
@@ -25,6 +25,7 @@ import (
 	"github.com/blugelabs/bleve/analysis"
 	"github.com/blugelabs/bleve/document"
 	"github.com/blugelabs/bleve/index"
+	"github.com/blugelabs/bleve/index/scorch/segment"
 	"github.com/blugelabs/vellum"
 	"github.com/golang/snappy"
 )
@@ -44,7 +45,7 @@ var ValidateDocFields = func(field document.Field) error {
 // AnalysisResultsToSegmentBase produces an in-memory zap-encoded
 // SegmentBase from analysis results
 func AnalysisResultsToSegmentBase(results []*index.AnalysisResult,
-	chunkFactor uint32) (*SegmentBase, uint64, error) {
+	chunkFactor uint32) (segment.Segment, uint64, error) {
 	s := interimPool.Get().(*interim)
 
 	var br bytes.Buffer

--- a/index/scorch/segment/zap/segment_test.go
+++ b/index/scorch/segment/zap/segment_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/RoaringBitmap/roaring"
 	"github.com/blugelabs/bleve/index"
 	"github.com/blugelabs/bleve/index/scorch/segment"
+	seg "github.com/blugelabs/bleve/index/scorch/segment"
 )
 
 func TestOpen(t *testing.T) {
@@ -687,9 +688,9 @@ func TestMergedSegmentDocsWithNonOverlappingFields(t *testing.T) {
 		}
 	}()
 
-	segsToMerge := make([]*Segment, 2)
-	segsToMerge[0] = segment1.(*Segment)
-	segsToMerge[1] = segment2.(*Segment)
+	segsToMerge := make([]seg.Segment, 2)
+	segsToMerge[0] = segment1
+	segsToMerge[1] = segment2
 
 	_, nBytes, err := Merge(segsToMerge, []*roaring.Bitmap{nil, nil}, "/tmp/scorch3.zap", 1024, nil, nil)
 	if err != nil {

--- a/index/scorch/segment_wrapper.go
+++ b/index/scorch/segment_wrapper.go
@@ -1,0 +1,90 @@
+//  Copyright (c) 2019 Couchbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scorch
+
+import (
+	"encoding/binary"
+	"fmt"
+
+	"github.com/RoaringBitmap/roaring"
+	"github.com/blugelabs/bleve/index"
+	"github.com/blugelabs/bleve/index/scorch/segment"
+	"github.com/blugelabs/bleve/index/scorch/segment/zap"
+)
+
+type segmentWrapperNew func(results []*index.AnalysisResult,
+	chunkFactor uint32) (segment.Segment, uint64, error)
+
+type segmentWrapperlOpen func(path string) (segment.Segment, error)
+
+type segmentWrapperMerge func(segments []segment.Segment, drops []*roaring.Bitmap, path string,
+	chunkFactor uint32, closeCh chan struct{}, s segment.StatsReporter) (
+	[][]uint64, uint64, error)
+
+type segmentWrapperValidateMerge func(segments []segment.Segment, drops []*roaring.Bitmap, newSegment segment.Segment) error
+
+type segmentWrapperIsDocNum1HitFinished func(docNum uint64) bool
+
+type segmentWrapperPostingsIteratorFromBitmap func(bm *roaring.Bitmap,
+	includeFreqNorm, includeLocs bool) (segment.PostingsIterator, error)
+
+type segmentWrapperPostingsIteratorFrom1Hit func(docNum1Hit uint64,
+	includeFreqNorm, includeLocs bool) (segment.PostingsIterator, error)
+
+type segmentWrapper struct {
+	Type                       string
+	Version                    uint32
+	New                        segmentWrapperNew
+	Open                       segmentWrapperlOpen
+	Merge                      segmentWrapperMerge
+	ValidateMerge              segmentWrapperValidateMerge
+	IsDocNum1HitFinished       segmentWrapperIsDocNum1HitFinished
+	PostingsIteratorFromBitmap segmentWrapperPostingsIteratorFromBitmap
+	PostingsIteratorFrom1Hit   segmentWrapperPostingsIteratorFrom1Hit
+}
+
+var supportedSegmentTypeVersions map[string]map[uint32]*segmentWrapper
+var defaultSegmentTypeVersion *segmentWrapper
+
+func init() {
+	supportedSegmentTypeVersions = map[string]map[uint32]*segmentWrapper{
+		zap.Type: map[uint32]*segmentWrapper{
+			zap.Version: &segmentWrapper{
+				Type:                       zap.Type,
+				Version:                    zap.Version,
+				New:                        zap.AnalysisResultsToSegmentBase,
+				Open:                       zap.Open,
+				Merge:                      zap.Merge,
+				ValidateMerge:              zap.ValidateMerge,
+				IsDocNum1HitFinished:       zap.IsDocNum1HitFinished,
+				PostingsIteratorFromBitmap: zap.PostingsIteratorFromBitmap,
+				PostingsIteratorFrom1Hit:   zap.PostingsIteratorFrom1Hit,
+			},
+		},
+	}
+	defaultSegmentTypeVersion = supportedSegmentTypeVersions[zap.Type][zap.Version]
+}
+
+func (s *Scorch) loadSegmentWrapper(segmentType, segmentVersion []byte) error {
+	if versions, ok := supportedSegmentTypeVersions[string(segmentType)]; ok {
+		version := binary.BigEndian.Uint32(segmentVersion)
+		if segWrapper, ok := versions[version]; ok {
+			s.segWrapper = segWrapper
+			return nil
+		}
+		return fmt.Errorf("unsupported version %d for segment type: %s, known: %#v", version, string(segmentType), versions)
+	}
+	return fmt.Errorf("unsupported segment type: %s", string(segmentType))
+}


### PR DESCRIPTION
The goal is to allow scorch to maintain a map of
supported segment impl types/versions.  And upon
opening an index, check that the required impl is
supported, and if so, use the correct impl.

New interfaces to differentiate between persisted and
unpersisted segments:

Persisted ones have a `Path() string` method
Unpersisted ones have a `Persist(path string) error` method

Many places that used *zap.Segment or *zap.SegmentBase were
migrated to these.

New single unified Merge() method in zap, which takes
[]segment.Segment instead of *Segment or *SegmentBase.
Type assertion is done inside this method (previously done
by scorch layer).  The assumption is that Merge should only
be called with with implementations this package will actually
be able to support.  If you call it with unsupported types,
the code will panic.

ValidateMerge signature changed to work with segment.Segment
instead of the impl structs, expect advanced users can adapt
accordingly.

New OptimizablePostingsIterator interface introduced to
describe optional capabilities of a PostingsIterator for
optimization.

Scorch no longer directly uses zap.<anything> instead, you use
the scorch instances segWrapper in it's place.  This
SegmentWrapper has pointers to required functions in a
upported implementation.

Scorch maintains a map of supported segment types and versions.
This map is populated in an init() function.  Allowing Bleve
packagers to decided which types/versions are going to be
supported by any given release of Bleve.  An open question
is if we should export this, or have some thread-safe way
for application builders to change this on their own.

Scorch also has a notion of a default segment wrapper, this
is simply a pointer to the one which should be used by default
in a new scorch index.

When opening and existing index, at the type the snapshot
is loaded, we first read the snapshot meta-data, which tells us
the segment impl type and version.  We look this up in the map,
and if it is supported, we use that going forward.  If the
type/version used in the snapshot is not supported, we refuse
to load that snapshot.  The existing logic is such that we
will continue to search backwards for a snapshot that we can
open.  This isn't particularly useful right now, but doesn't
seem harmful either.